### PR TITLE
Ignore automatically generated README in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build
 /Unicode-CaseFold-*
+README


### PR DESCRIPTION
Since the README file is automatically generated, it makes sense to have git ignore it, and thus to have a clean working directory even after a build or test run.