### PR TITLE
Move strict/warnings pragmas before first statement

### DIFF
--- a/lib/Unicode/CaseFold.pm
+++ b/lib/Unicode/CaseFold.pm
@@ -2,13 +2,13 @@ package Unicode::CaseFold;
 
 # ABSTRACT: Unicode case-folding for case-insensitive lookups.
 
+use strict;
+use warnings;
+
 BEGIN {
   # VERSION
 }
 # AUTHORITY
-
-use strict;
-use warnings;
 
 use 5.008001;
 


### PR DESCRIPTION
Perlcritic warns that code appears before the strict and warnings pragmas.  Moving the pragmas before the first BEFORE block keeps perlcritic happier.

This PR is submitted in the hope that it is useful.  If you have any questions or comments concerning it, please don't hesitate to contact me.