### PR TITLE
Add 'provides' info to META.yml output

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,3 +20,5 @@ remove = XSLoader
 XSLoader = 0
 
 [SurgicalPodWeaver]
+
+[MetaProvides::Package]


### PR DESCRIPTION
[CPANTS](http://cpants.cpanauthors.org/dist/Unicode-CaseFold) mentions that the 'provides' section is missing from the `META.yml` file.  This PR adds the `MetaProvides` plugin so that this information can be created automatically at dist build time.  I'm guessing, however, that you might want to add this to your Dist::Zilla plugin bundle, so effectively this PR is to let you know of the issue should you wish to add 'provides' info to the META output.

This PR is submitted in the hope that it is useful.  If you have any questions or comments, please feel free to contact me.